### PR TITLE
Refactoring of the user TOML inner workings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ provisioners {
 
 ## Requirements
 * This provisioner will currently only work on Linux targets.  As the Habitat supervisor becomes available on more systems, support for those will be added.
-* Currently, we assume several userspace utilities on the target system (curl, wget, setsid, etc).  
+* Currently, we assume several userspace utilities on the target system (curl, wget, setsid, tee, etc).  
 * You must have SSH access as root or a user that can passwordless sudo.
 
 ## Usage


### PR DESCRIPTION
Moved from using the communicator's file upload method.  The upload
method required giving extra access to the `/hab/svc/<name>` dir to
allow uploading.  We're now just echo'ing out to tee so that we can
drop the file off in the right place whether we're root or not by using
sudo.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>